### PR TITLE
type error when loading data

### DIFF
--- a/vnpy_duckdb/duckdb_database.py
+++ b/vnpy_duckdb/duckdb_database.py
@@ -131,8 +131,8 @@ class DuckdbDatabase(BaseDatabase):
             "symbol": symbol,
             "exchange": exchange.value,
             "interval": interval.value,
-            "start": str(start),
-            "end": str(end)
+            "start": start,
+            "end": end
         }
 
         self.execute(LOAD_BAR_QUERY, params)


### PR DESCRIPTION
File "F:\Space\CryptoQuant\plugins\duckdb\duckdb_database.py", line 138, in load_bar_data
    self.execute(LOAD_BAR_QUERY, params)
  File "F:\Space\CryptoQuant\plugins\duckdb\duckdb_database.py", line 232, in execute
    self.cursor.execute(query, data)
duckdb.duckdb.BinderException: Binder Error: Cannot compare values of type TIMESTAMP and type VARCHAR - an explicit cast is required LINE 6: AND datetime >= $start